### PR TITLE
Prevent false positives on search

### DIFF
--- a/inc/scripts.js
+++ b/inc/scripts.js
@@ -27,10 +27,10 @@ $(document).ready(function(){
 	}
 
 	var term = $(this).val().toLowerCase();
-    var $sites = $('.sites').children('section');
+    var $sites = $('.sites section');
 
     $sites.show().filter(function() {
-        var text = $(this).text().replace(/\s+/g, ' ').toLowerCase();
+        var text = $(this).find('a').text().replace(/\s+/g, ' ').toLowerCase();
         return !~text.indexOf(term);
     }).hide();
 


### PR DESCRIPTION
Search currently includes the notes, so searching "close" matches any sites which "close" in the notes. This corrects it so that it searches only site titles.
