### PR TITLE
Change WordPress to WordPress.com

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -161,7 +161,7 @@
  	},
 
  	{
- 		"name" : "WordPress",
+ 		"name" : "WordPress.com",
  		"url" : "http://en.support.wordpress.com/deleting-accounts/",
  		"difficulty" : "impossible",
  		"notes" : "“WordPress.com accounts cannot be deleted.” The best you can do is remove any identifying data from your account."


### PR DESCRIPTION
The actual name of the service run at http://wordpress.com/ is "WordPress.com". WordPress is the open source project that one can download and install on a server they control.
