### PR TITLE
Update scripts - jQuery animation stop

### DIFF
--- a/inc/scripts.js
+++ b/inc/scripts.js
@@ -26,6 +26,7 @@ $(function(){
 	$('.site').hover(function () {
 		$(this).find('.tooltip').fadeIn();
 	}, function () {
+		$(this).find('.tooltip').stop();
 		$(this).find('.tooltip').fadeOut('fast');
 	});
 


### PR DESCRIPTION
Prevents the tooltip from accruing a queue of animations if the user mouses in and out of it multiple times quickly.

Makes scrolling through the site much cleaner.
