### PR TITLE
Fixed VK/ВКонтакте

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -810,7 +810,6 @@
 		{
 		"name" : "VK/ВКонтакте",
 		"url" : "http://vk.com/settings?act=deactivate",
-		"difficulty" : "easy",
-		"notes" : ""
+		"difficulty" : "easy"
 	}
 ]


### PR DESCRIPTION
Empty notes imply that there are notes in the UI, and "Show info..." is displayed even though there is no info to be shown.
