### PR TITLE
jQuery library to use Google CDN-hosted version

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE HTML>
 <html>
 <head>
@@ -18,7 +17,9 @@
 	<link rel="apple-touch-icon-precomposed" href="inc/icons/apple-touch-icon-144x144-precomposed.png">
 
 	<link rel="stylesheet" type="text/css" href="style.css" />
-	<script src="inc/jquery.js"></script>
+	
+	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+	<script>window.jQuery || document.write('<script src="inc/jquery.js"><\/script>')</script>
 	<script src="inc/scripts.js"></script>
 
 	<script type="text/javascript">


### PR DESCRIPTION
Update jQuery library to use Google CDN-hosted version which is faster/cheaper. (source: http://encosia.com/3-reasons-why-you-should-let-google-host-jquery-for-you/).

Used local fallback technique suggested by HTML5boilerplate (source: https://github.com/h5bp/html5-boilerplate/blob/master/index.html )
