### PR TITLE
Couchsurfing does not delete profiles

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -177,8 +177,8 @@
     {
         "name": "Couchsurfing",
         "url": "https://www.couchsurfing.org/delete_profile.html?delete=1",
-        "difficulty": "easy",
-        "notes": "Fill out the form and select 'I understand. Please delete my profile.'"
+        "difficulty": "impossible",
+        "notes": "Fill out the form and select 'I understand. Please delete my profile.'. Profile will be deactivated."
     },
 
     {


### PR DESCRIPTION
When you delete you account on couchsurfing.com, they even tell you that you can request a reactivation and that creating another one instead violates the T.O.S.
