### PR TITLE
wunderlist typo; added additional data for facebook

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -335,7 +335,8 @@
     {
         "name": "Facebook",
         "url": "https://www.facebook.com/help/delete_account?rdrhc",
-        "difficulty": "easy"
+        "difficulty": "easy",
+        "notes": "While you can delete your account easily, some of the datas including chat- or group-messages are here to stay forever, just as stated in the website's Privacy."
     },
 
     {
@@ -1289,7 +1290,7 @@
         "name": "Wunderlist",
         "url": "https://www.wunderlist.com/#/preferences/account",
         "difficulty": "easy",
-        "notes": "Click 'Delete Account' at the bottom of the account preferences pane"
+        "notes": "Click 'Delete Account' at the bottom of the account preferences panel."
     },
 
     {


### PR DESCRIPTION
Just as facebook [states](https://www.facebook.com/full_data_use_policy#deleting), things like chat messages or group posts are not linked to the account, thus are staying on their server ignoring the fact that a person has marked his account for deletion.
