### PR TITLE
The Kippt account deletion URL gives a 404

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -1397,7 +1397,7 @@
 
     {
         "name": "Kippt",
-        "url": "https://kippt.com/accounts/delete",
+        "url": "https://kippt.com/accounts/delete/",
         "difficulty": "easy",
         "notes": "Click 'Account deletion page' at the bottom of the account settings page."
     },


### PR DESCRIPTION
Adding a final slash to the URL fixes it.
