### PR TITLE
Add PayPal instructions

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -1903,7 +1903,8 @@
     {
         "name": "PayPal",
         "url": "https://www.paypal.com/us/cgi-bin/webscr?cmd=_close-account",
-        "difficulty": "easy"
+        "difficulty": "easy",
+        "notes": "Log in. Click 'Profile' near the top of the page. Click 'My settings'. Click 'Close Account' in the 'Account type' section and follow the steps listed."
     },
 
     {


### PR DESCRIPTION
I was hesitant to click directly on a "delete account" link, so I added the missing instructions to close a PayPal account.
