### PR TITLE
Add entry for mailbox.org to sites.json

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -3125,6 +3125,16 @@
     },
 
     {
+        "name": "mailbox.org",
+        "url": "https://support-en.mailbox.org/knowledge-base/article/terminate-my-account",
+        "difficulty": "easy",
+        "notes": "The mailbox.org interface provides a form to terminate your account and request a refund. (Log into your account → Settings → mailbox.org → Cancel Account)",
+        "domains": [
+            "mailbox.org"
+        ]
+    },
+
+    {
         "name": "Mapbox",
         "url": "https://www.mapbox.com/account/billing/",
         "difficulty": "easy",


### PR DESCRIPTION
No translations, as as of just having it tested right now in several languages, the "Cancel Account" menu is not there in other languages than German and English, or I just could't see it! And their site seems to have some issues in general when it comes to the translations as some menus and submenus are not translated even after logging out-and-in and read in English.