### PR TITLE
Fix codecademy delete link

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -841,7 +841,7 @@
 
     {
         "name": "Codecademy",
-        "url": "http://help.codecademy.com/customer/portal/articles/1394081-how-do-i-delete-my-account-",
+        "url": "https://www.codecademy.com/account/delete_acct",
         "difficulty": "easy",
         "notes": "Simply click the \"I understand, delete my account.\" button.",
         "notes_it": "Per ragioni di sicurezza, dobbiamo verificare che queste richieste ci arrivino dall'email che è registrata sul tuo account Codacademy",


### PR DESCRIPTION
Currently the old page cannot be found and return a 404 page. So I updated it to the page where you can directly press the button in order to delete the account.