### PR TITLE
Add Facebook Messenger

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -1542,6 +1542,13 @@
     },
 
     {
+        "name": "Facebook Messenger",
+        "difficulty": "impossible",
+        "notes": "If you logged in with your Facebook account, you can just delete that account. If you registered using your phone number, there's no way to delete your account",
+        "notes_es": "Si iniciaste sesión con tu cuenta de Facebook, podés borrar esa cuenta. Si te registraste con tu número de celular, no hay forma de eliminar tu cuenta"
+    },
+
+    {
         "name": "Facile.it",
         "url": "https://www.facile.it/cancellazione/",
         "difficulty": "easy",


### PR DESCRIPTION
There's no URL, because there are no relevant help articles, or *anything*. There's not even an account page or anything alike, it's all inside the mobile app.