### PR TITLE
Adds Uber.com and Update Spotify

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -4636,7 +4636,7 @@
 
     {
         "name": "Spotify",
-        "url": "https://support.spotify.com/close/",
+        "url": "https://support.spotify.com/co/close-account/",
         "difficulty": "easy",
         "domains": [
             "spotify.com",

--- a/sites.json
+++ b/sites.json
@@ -5099,7 +5099,18 @@
             "typepad.com"
         ]
     },
-
+    
+    {
+        "name": "Uber",
+        "url": "https://myprivacy.uber.com/privacy/deleteyouraccount",
+        "difficulty": "easy",
+        "notes": "Just login into your account using thah link and confirm the deletion.",
+        "notes_es": "Simplemente hay que iniciar sesion en ese enlace y confirmar la eliminación de la cuenta.",
+        "domains": [
+            "uber.com"
+        ]
+    },
+    
     {
         "name": "Ubuntu One",
         "url": "https://one.ubuntu.com/help/faq/how-can-i-delete-my-account/",


### PR DESCRIPTION
Adds the direct link to the deletion account site for Uber.com

and update the one for spotify, since the previous one goes 404
the link was found in: https://community.spotify.com/t5/FAQs/How-do-I-close-delete-my-Spotify-Account/ta-p/4663172